### PR TITLE
Fix misspelled word

### DIFF
--- a/src/chapters/data-and-variables/operations.rst
+++ b/src/chapters/data-and-variables/operations.rst
@@ -291,7 +291,7 @@ Check Your Understanding
 
    What is the value of the following expression?
 
-   *Note:* Using the **^** "carrot" symbol is common short hand for showing exponentiation, but not used in C#.
+   *Note:* Using the **^** "caret" symbol is common short hand for showing exponentiation, but not used in C#.
 
    .. sourcecode:: csharp
 


### PR DESCRIPTION
The correct spelling for the '^' symbol is caret. It was misspelled as "carrot" which is a vegetable.